### PR TITLE
feat: turn off no-empty-function and type-def rules

### DIFF
--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -77,11 +77,13 @@ const rules: ESLint.ConfigData['rules'] = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/ban-ts-comment': 'warn', // Discourage disabling static analysis.
     '@typescript-eslint/ban-types': 'warn', // Discourage disabling static analysis.
+    '@typescript-eslint/consistent-type-definitions': 'off',
     '@typescript-eslint/consistent-type-imports': [
         'error',
         { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
     ],
     '@typescript-eslint/no-duplicate-enum-values': 'warn',
+    '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-for-in-array': 'error',
     '@typescript-eslint/no-non-null-asserted-nullish-coalescing': 'error',
     '@typescript-eslint/prefer-includes': 'warn',


### PR DESCRIPTION
Turn off `@typescript-eslint/no-empty-function` and `@typescript-eslint/consistent-type-definitions` by default.