### PR TITLE
feat: remove prettier and eslint-plugin-prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,12 +78,10 @@
         "eslint-plugin-import-x": "^4.5.0",
         "eslint-plugin-jest": "^28.9.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
-        "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-testing-library": "^7.1.1",
         "husky": "^9.1.7",
-        "prettier": "^3.4.2",
         "semantic-release": "^24.2.6",
         "semantic-release-yarn": "^3.0.2",
         "typescript": "^5.8.3",
@@ -100,11 +98,9 @@
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import-x": "^4.5.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
-        "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-testing-library": "^7.1.1",
-        "prettier": "^3.2.5",
         "typescript": ">=5.3",
         "typescript-eslint": "^8.0.0"
     },
@@ -119,9 +115,6 @@
             "optional": true
         },
         "eslint-plugin-jsx-a11y": {
-            "optional": true
-        },
-        "eslint-plugin-prettier": {
             "optional": true
         },
         "eslint-plugin-react": {

--- a/src/base/index.ts
+++ b/src/base/index.ts
@@ -2,8 +2,6 @@ import js from '@eslint/js'
 import importPlugin from 'eslint-plugin-import-x'
 import ts from 'typescript-eslint'
 
-import { importModuleIfExists } from '../util/index.js'
-
 import { languageOptions } from './languageOptions.js'
 import { rules } from './rules.js'
 import { settings } from './settings.js'
@@ -13,7 +11,6 @@ export default [
     ...ts.configs.recommended,
     ...ts.configs.stylistic,
     importPlugin.flatConfigs.recommended,
-    await importModuleIfExists('eslint-plugin-prettier/recommended'),
     {
         files: [
             '**/*.ts',

--- a/src/base/rules.ts
+++ b/src/base/rules.ts
@@ -1,16 +1,4 @@
 export const rules = {
-    'prettier/prettier': [
-        'error',
-        {
-            printWidth: 80,
-            tabWidth: 4,
-            semi: false,
-            trailingComma: 'all',
-            singleQuote: true,
-            allowParens: 'always',
-        },
-    ],
-
     /** Errors */
     'no-var': 'error',
     'prefer-const': 'error',

--- a/yarn.lock
+++ b/yarn.lock
@@ -438,13 +438,11 @@ __metadata:
     eslint-plugin-import-x: "npm:^4.5.0"
     eslint-plugin-jest: "npm:^28.9.0"
     eslint-plugin-jsx-a11y: "npm:^6.10.2"
-    eslint-plugin-prettier: "npm:^5.2.1"
     eslint-plugin-react: "npm:^7.37.2"
     eslint-plugin-react-hooks: "npm:^5.1.0"
     eslint-plugin-testing-library: "npm:^7.1.1"
     globals: "npm:^16.3.0"
     husky: "npm:^9.1.7"
-    prettier: "npm:^3.4.2"
     semantic-release: "npm:^24.2.6"
     semantic-release-yarn: "npm:^3.0.2"
     typescript: "npm:^5.8.3"
@@ -460,11 +458,9 @@ __metadata:
     eslint-import-resolver-typescript: ^3.6.1
     eslint-plugin-import-x: ^4.5.0
     eslint-plugin-jsx-a11y: ^6.10.2
-    eslint-plugin-prettier: ^5.1.3
     eslint-plugin-react: ^7.37.2
     eslint-plugin-react-hooks: ^5.1.0
     eslint-plugin-testing-library: ^7.1.1
-    prettier: ^3.2.5
     typescript: ">=5.3"
     typescript-eslint: ^8.0.0
   peerDependenciesMeta:
@@ -475,8 +471,6 @@ __metadata:
     eslint-plugin-jest:
       optional: true
     eslint-plugin-jsx-a11y:
-      optional: true
-    eslint-plugin-prettier:
       optional: true
     eslint-plugin-react:
       optional: true
@@ -876,13 +870,6 @@ __metadata:
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 10/115e8ceeec6bc69dff2048b35c0ab4f8bbee12d8bb6c1f4af758604586d802b6e669dcb02dda61d078de42c2b4ddce41b3d9e726d7daa6b4b850f4adbf7333ff
-  languageName: node
-  linkType: hard
-
-"@pkgr/core@npm:^0.1.0":
-  version: 0.1.1
-  resolution: "@pkgr/core@npm:0.1.1"
-  checksum: 10/6f25fd2e3008f259c77207ac9915b02f1628420403b2630c92a07ff963129238c9262afc9e84344c7a23b5cc1f3965e2cd17e3798219f5fd78a63d144d3cceba
   languageName: node
   linkType: hard
 
@@ -2960,26 +2947,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-prettier@npm:^5.2.1":
-  version: 5.2.1
-  resolution: "eslint-plugin-prettier@npm:5.2.1"
-  dependencies:
-    prettier-linter-helpers: "npm:^1.0.0"
-    synckit: "npm:^0.9.1"
-  peerDependencies:
-    "@types/eslint": ">=8.0.0"
-    eslint: ">=8.0.0"
-    eslint-config-prettier: "*"
-    prettier: ">=3.0.0"
-  peerDependenciesMeta:
-    "@types/eslint":
-      optional: true
-    eslint-config-prettier:
-      optional: true
-  checksum: 10/10ddf68215237e327af09a47adab4c63f3885fda4fb28c4c42d1fc5f47d8a0cc45df6484799360ff1417a0aa3c77c3aaac49d7e9dfd145557b17e2d7ecc2a27c
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-react-hooks@npm:^5.1.0":
   version: 5.1.0
   resolution: "eslint-plugin-react-hooks@npm:5.1.0"
@@ -3220,13 +3187,6 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 10/e21a9d8d84f53493b6aa15efc9cfd53dd5b714a1f23f67fb5dc8f574af80df889b3bce25dc081887c6d25457cce704e636395333abad896ccdec03abaf1f3f9d
-  languageName: node
-  linkType: hard
-
-"fast-diff@npm:^1.1.2":
-  version: 1.3.0
-  resolution: "fast-diff@npm:1.3.0"
-  checksum: 10/9e57415bc69cd6efcc720b3b8fe9fdaf42dcfc06f86f0f45378b1fa512598a8aac48aa3928c8751d58e2f01bb4ba4f07e4f3d9bc0d57586d45f1bd1e872c6cde
   languageName: node
   linkType: hard
 
@@ -6072,24 +6032,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier-linter-helpers@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "prettier-linter-helpers@npm:1.0.0"
-  dependencies:
-    fast-diff: "npm:^1.1.2"
-  checksum: 10/00ce8011cf6430158d27f9c92cfea0a7699405633f7f1d4a45f07e21bf78e99895911cbcdc3853db3a824201a7c745bd49bfea8abd5fb9883e765a90f74f8392
-  languageName: node
-  linkType: hard
-
-"prettier@npm:^3.4.2":
-  version: 3.4.2
-  resolution: "prettier@npm:3.4.2"
-  bin:
-    prettier: bin/prettier.cjs
-  checksum: 10/a3e806fb0b635818964d472d35d27e21a4e17150c679047f5501e1f23bd4aa806adf660f0c0d35214a210d5d440da6896c2e86156da55f221a57938278dc326e
-  languageName: node
-  linkType: hard
-
 "pretty-ms@npm:^9.0.0":
   version: 9.2.0
   resolution: "pretty-ms@npm:9.2.0"
@@ -7095,16 +7037,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"synckit@npm:^0.9.1":
-  version: 0.9.1
-  resolution: "synckit@npm:0.9.1"
-  dependencies:
-    "@pkgr/core": "npm:^0.1.0"
-    tslib: "npm:^2.6.2"
-  checksum: 10/bff3903976baf8b699b5483228116d70223781a93b17c70e685c277ee960cdfd1a09cb5a741e6a9ec35e2428f14f4664baec41ccc99a598f267608b2a54f529b
-  languageName: node
-  linkType: hard
-
 "tapable@npm:^2.2.0":
   version: 2.2.1
   resolution: "tapable@npm:2.2.1"
@@ -7287,7 +7219,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.4.0, tslib@npm:^2.6.2, tslib@npm:^2.6.3":
+"tslib@npm:^2.4.0, tslib@npm:^2.6.3":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10/3e2e043d5c2316461cb54e5c7fe02c30ef6dccb3384717ca22ae5c6b5bc95232a6241df19c622d9c73b809bea33b187f6dbc73030963e29950c2141bc32a79f7


### PR DESCRIPTION
BREAKING CHANGE: This update removes support for eslint-plugin-prettier. Using this plugin is not recommended by prettier, and often causes issues with yarn modern. As a result, it has been removed from this major version update. Configure prettier seprately instead.